### PR TITLE
Use meteor module imports to enable use of new testing framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ The templates need to be accessible to the server (i.e. put them inside your
 The handlebars files should just be regular HTML. Don't wrap them in Meteor
 `<template>` tag.
 
+You must import the `Handlebars` namespace as shown below before using.
+
 Example:
 
 **my-template.handlebars**
@@ -23,7 +25,8 @@ hello, Dr. {{name}}
 ```
 
 **my-server-code.js**
-```
+```javascript
+import { Handlebars } from 'meteor/astrocoders:handlebars-server';
 Handlebars.templates["my-template"]({name: "Who"});
 // > hello, Dr. Who
 ```

--- a/handlebars-server-tests.js
+++ b/handlebars-server-tests.js
@@ -1,3 +1,5 @@
+import { Handlebars } from 'meteor/astrocoders:handlebars-server';
+
 Tinytest.add("handlebars-server", function (test) {
   var tmpl = Handlebars.templates['handlebars-server-tests'];
   var result = tmpl({name: 'test'});

--- a/handlebars-server.js
+++ b/handlebars-server.js
@@ -1,6 +1,11 @@
-OriginalHandlebars = Npm.require('handlebars');
-Handlebars = Handlebars || {};
+import OriginalHandlebars from 'handlebars';
 
+const Handlebars = global.Handlebars || {};
 _.extend(Handlebars, {
-  templates: {},
+  templates: {}
 });
+
+export {
+  OriginalHandlebars,
+  Handlebars
+};

--- a/package.js
+++ b/package.js
@@ -16,6 +16,7 @@ Package.registerBuildPlugin({
   use: [
     'caching-compiler@1.0.0',
     'ecmascript',
+    'modules',
     'ejson@1.0.7',
   ],
 
@@ -29,15 +30,16 @@ Package.registerBuildPlugin({
 });
 
 Package.onUse(function(api){
-  api.versionsFrom('1.2.0.1');
+  api.versionsFrom('1.3.1');
 
   api.use([
     'ecmascript',
+    'modules',
     'underscore',
     'isobuild:compiler-plugin@1.0.0',
   ], 'server');
 
-  api.addFiles('handlebars-server.js', 'server');
+  api.mainModule('handlebars-server.js', 'server');
 
   api.export([
     'Handlebars',
@@ -47,14 +49,16 @@ Package.onUse(function(api){
 
 Package.onTest(function (api) {
   api.use([
+    'ecmascript',
+    'modules',
     'tinytest',
-   'astrocoders:handlebars-server',
-   'test-helpers',
+    'astrocoders:handlebars-server',
+    'test-helpers',
   ], 'server');
 
+  api.mainModule('handlebars-server-tests.js', 'server');
   api.addFiles([
     'handlebars-server-tests.handlebars',
     'handlebars-server-tests-2.handlebars',
-    'handlebars-server-tests.js'
   ], 'server');
 });

--- a/plugin/compile-handlebars.js
+++ b/plugin/compile-handlebars.js
@@ -1,5 +1,6 @@
 /* jshint esnext: true */
-const path = Plugin.path;
+import {CachingCompiler} from 'meteor/caching-compiler';
+import {EJSON} from 'meteor/ejson';
 
 Plugin.registerCompiler({
   extensions: ['handlebars', 'hbs'],
@@ -28,20 +29,20 @@ class HandlebarsServer extends CachingCompiler {
   }
 
   compileHandlebar(file){
-    const templateName = file.getBasename().replace(/(.hbs)|(.handlebars)/, '');
+    const templateName = EJSON.stringify(file.getBasename().replace(/(\.hbs)|(\.handlebars)/, ''));
 
     const content = EJSON.stringify(file.getContentsAsString());
 
     const output =`
-      Handlebars.templates = Handlebars.templates || {};
-      var template = OriginalHandlebars.compile(${content});
-      Handlebars.templates['${templateName}'] = function(data, partials){
+      var handlebarsServer = require('meteor/astrocoders:handlebars-server');
+      var template = handlebarsServer.OriginalHandlebars.compile(${content});
+      handlebarsServer.Handlebars.templates[${templateName}] = function(data, partials){
         partials = partials || {};
         return template(data || {}, {
-          helpers: OriginalHandlebars.helpers,
+          helpers: handlebarsServer.OriginalHandlebars.helpers,
           partials: partials,
-          name: '${templateName}'
-         });
+          name: ${templateName}
+        });
       }`;
 
     return output;


### PR DESCRIPTION
Without these changes I couldn't get my templates to show up under `Handlebars.templates` when running unit tests.